### PR TITLE
Upgraded pg from v0.18.4 -> v1.2.3 for production.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,5 +46,5 @@ group :test do
 end
 
 group :production do
-  gem 'pg', '~> 0.18.4'
+  gem 'pg', '~> 1.2.3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
     parallel (1.20.1)
     parser (3.0.2.0)
       ast (~> 2.4.1)
-    pg (0.18.4)
+    pg (1.2.3)
     pie-rails (1.1.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -288,7 +288,7 @@ DEPENDENCIES
   jquery-rails
   nokogiri (>= 1.7.1)
   oj
-  pg (~> 0.18.4)
+  pg (~> 1.2.3)
   pie-rails (~> 1.1)
   pry (~> 0.10.3)
   puma


### PR DESCRIPTION
Missed the need to upgrade the PostgreSQL gem `pg` in the Rails 6.1 upgrade 

![drat](https://media0.giphy.com/media/5zqe2SpxdnzBT3jJnX/giphy.gif?cid=ecf05e47twvva67jdxcxw0ybtsueqo0hhonqtv7iloymddb7&rid=giphy.gif&ct=g)